### PR TITLE
Fix passing the register context to isr_handler

### DIFF
--- a/kernel/src/CPU/interrupts/interrupt.asm
+++ b/kernel/src/CPU/interrupts/interrupt.asm
@@ -66,6 +66,7 @@ extern isr_handler
 isr_common:
     pushaq
     
+    mov rdi, rsp
     call isr_handler
     
     popaq

--- a/kernel/src/CPU/interrupts/isr.c
+++ b/kernel/src/CPU/interrupts/isr.c
@@ -130,10 +130,12 @@ void isr31_handler() {
 }
 
 void isr_handler(Registers* regs) {
-    // print(toString(regs->interrupt));
+    print("Error: ");
+    print(toString(regs->error));
+    print(", Vector: ");
+    print(toString(regs->interrupt));
+    print(" ");
     print("test");
-    while(true);
-    // return;
 }
 
 void install() {

--- a/kernel/src/includes/isr.h
+++ b/kernel/src/includes/isr.h
@@ -11,10 +11,10 @@ extern void isr14();
 
 typedef struct 
 {
-    uint64_t ds;
-    uint64_t rdi, rsi, rbp, rsp, rbx, rdx, rcx, rax;
-    uint64_t interrupt, error; 
-    uint64_t rip, cs, rflags, rsp_user, ss; 
+    uint64_t r15, r14, r13, r12, r11, r10, r9, r8;
+    uint64_t rdi, rsi, rbp, rbx, rdx, rcx, rax;
+    uint64_t error, interrupt, ignore; 
+    uint64_t rip, cs, rflags, rsp, ss; 
 } __attribute__((packed)) Registers;
 
 typedef void (*ISRHandler)(Registers* regs);


### PR DESCRIPTION
Add missing registers to `Registers`, pass RSP to `isr_handler`.